### PR TITLE
lower case repo name

### DIFF
--- a/src/terminator.js
+++ b/src/terminator.js
@@ -78,7 +78,7 @@ export default async function checkPayload(ctx) {
 	const { pull_request, zen, action } = ctx.request.body;
 	const { head, number: pullRequestId } = pull_request;
 	const { repo, sha } = head;
-	const repoName = repo.full_name;
+	const repoName = repo.full_name.toLowerCase();
 
 	const isSupportedRepo = config.get('repos').includes(repoName);
 


### PR DESCRIPTION
Otherwise it won't match the supported repos

Webhook logs in GitHub
> `Unsupported update: opened for Magnetme/magnet.me`