### PR TITLE
Standardize the JavaScript Docker runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,27 @@
-FROM node:24-alpine
-MAINTAINER Rogier Slag
+FROM node:24.8-alpine
 
 EXPOSE 8543
 
-WORKDIR /opt/terminator
+RUN addgroup -S -g 1024 javascript
+RUN adduser -D -S -u 1024 -G javascript -h /opt/terminator javascript
+RUN mkdir -p /opt/terminator/config
+RUN chown -R javascript:javascript /opt/terminator
+
 # Set the config volume
-VOLUME /opt/terminator/config
+VOLUME ["/opt/terminator/config"]
+
+USER javascript:javascript
+WORKDIR /opt/terminator
 
 # Set the application
-COPY .babelrc .
-COPY .eslintrc.js .
-COPY package.json .
-COPY yarn.lock .
-RUN yarn install --frozen-lockfile
-COPY src ./src
+COPY --chown=javascript:javascript .babelrc .
+COPY --chown=javascript:javascript .eslintrc.js .
+COPY --chown=javascript:javascript package.json .
+COPY --chown=javascript:javascript yarn.lock .
+RUN yarn install --frozen-lockfile && yarn cache clean
+COPY --chown=javascript:javascript src ./src
 
 RUN yarn build
-RUN yarn install --production --frozen-lockfile --ignore-scripts --prefer-offline
 
 # Start it!
 CMD ["node", "out/server.js"]


### PR DESCRIPTION
Terminator's image currently runs dependency installation, compilation, and the service as root. It also follows the moving Node 24 Alpine tag, which makes rebuilds less predictable.

This pins the image to Node 24.8 Alpine and adds a dedicated `javascript` user with UID/GID 1024. Application and source files are copied with the matching ownership, Yarn's cache is cleaned after the frozen install, and the build uses one deterministic dependency installation rather than running it twice. The config volume, port, and direct Node entrypoint stay unchanged.
